### PR TITLE
Fix HTTP-level authorization errors showing as JSON decoding errors

### DIFF
--- a/molgenis/client.py
+++ b/molgenis/client.py
@@ -354,7 +354,10 @@ class Session:
         """Raises an exception with error message from molgenis"""
         message = ex.args[0]
         if ex.response.content:
-            error = json.loads(ex.response.content.decode("utf-8"))['errors'][0]['message']
+            try:
+                error = json.loads(ex.response.content.decode("utf-8"))['errors'][0]['message']
+            except ValueError:  # Cannot parse JSON
+                error = ex.response.content
             error_msg = '{}: {}'.format(message, error)
             raise MolgenisRequestError(error_msg, ex.response)
         else:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,6 +3,17 @@ import unittest, sys, os
 import molgenis.client as molgenis
 
 
+class RepsonseMock:
+    def __init__(self, content):
+        self.content = content
+
+
+class ExceptionMock:
+    def __init__(self, message, response):
+        self.args = [message]
+        self.response = RepsonseMock(response)
+
+
 class TestStringMethods(unittest.TestCase):
     """
     Tests the client against a running MOLGENIS.
@@ -287,6 +298,16 @@ class TestStringMethods(unittest.TestCase):
                             'sort': ['x', None]}
         with self.assertRaises(TypeError):
             self.session._build_api_url(base_url, possible_options)
+
+    def test_raise_exception_with_missing_content(self):
+        msg = 'message'
+        ex = ExceptionMock(msg, None)
+        try:
+            self.session._raise_exception(ex)
+        except Exception as e:
+            message = e.args[0]
+            expected = msg
+            self.assertEqual(expected, message)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When getting a response from the server that has content the client tries to parse it as JSON, which is not always the case:
 ```
File "/hpc/local/CentOS7/common/lang/python/3.6.1/lib/python3.6/json/decoder.py", line 357, in raw_decode
   raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
From a content that represents the HTML page informing about a 403 access denied.

This ensures that if the JSON parsing of the content goes wrong, the user still receives some information.