### PR TITLE
Fix: get_by_id expand not correctly formatted for v2

### DIFF
--- a/molgenis/client.py
+++ b/molgenis/client.py
@@ -75,16 +75,19 @@ class Session:
 
         Args:
         entity -- fully qualified name of the entity
-        id -- the value for the idAttribute of the entity
+        id_ -- the value for the idAttribute of the entity
         attributes -- The list of attributes to retrieve
-        expand -- the attributes to expand
+        expand -- the attributes to expand, string with commas to separate multiple attributes.
 
         Examples:
-        session.get('Person', 'John')
+        >>> session = Session('http://localhost:8080/api/')
+        >>> session.get(entity='Person', id_='John', expand='name,age')
         """
-        response = self._session.get(self._url + "v2/" + quote_plus(entity) + '/' + quote_plus(id_),
-                                     headers=self._get_token_header(),
-                                     params={"attributes": attributes, "expand": expand})
+        possible_options = {'attrs': [attributes, expand]}
+
+        url = self._build_api_url(self._url + "v2/" + quote_plus(entity) + '/' + quote_plus(id_), possible_options)
+        response = self._session.get(url, headers=self._get_token_header())
+
         try:
             response.raise_for_status()
         except requests.RequestException as ex:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -27,6 +27,13 @@ class TestStringMethods(unittest.TestCase):
                                       "permission on entity type 'User' with id 'sys_sec_User'.".format(api_url)
     user_entity = 'sys_sec_User'
     ref_entity = 'org_molgenis_test_python_TypeTestRef'
+    expected_ref_data = [
+                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref1', 'value': 'ref1', 'label': 'label1'},
+                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref2', 'value': 'ref2', 'label': 'label2'},
+                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref3', 'value': 'ref3', 'label': 'label3'},
+                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref4', 'value': 'ref4', 'label': 'label4'},
+                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref5', 'value': 'ref5', 'label': 'label5'},
+                    ]
     session = molgenis.Session(api_url)
     session.login('admin', password)
 
@@ -67,17 +74,21 @@ class TestStringMethods(unittest.TestCase):
         s.get(self.user_entity)
         s.logout()
         try:
-            s.get(self.user_entity)
+            s._get_batch(self.user_entity)
         except Exception as e:
             message = e.args[0]
+            response = e.args[1]
+            response.connection.close()
             self.assertEqual(self.no_readmeta_permission_user_msg, message)
 
     def test_no_login_and_get_MolgenisUser(self):
         s = molgenis.Session(self.api_url)
         try:
-            s.get(self.user_entity)
+            s._get_batch(self.user_entity)
         except Exception as e:
             message = e.args[0]
+            response = e.args[1]
+            response.connection.close()
             self.assertEqual(self.no_readmeta_permission_user_msg, message)
 
     def test_upload_zip(self):
@@ -186,12 +197,7 @@ class TestStringMethods(unittest.TestCase):
 
     def test_get(self):
         data = self.session.get(self.ref_entity)
-        expected = [{'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref1', 'value': 'ref1', 'label': 'label1'},
-                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref2', 'value': 'ref2', 'label': 'label2'},
-                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref3', 'value': 'ref3', 'label': 'label3'},
-                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref4', 'value': 'ref4', 'label': 'label4'},
-                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref5', 'value': 'ref5', 'label': 'label5'}]
-        self.assertEqual(expected, data)
+        self.assertEqual(self.expected_ref_data, data)
 
     def test_get_raw(self):
         data = self.session.get(self.ref_entity, raw=True)
@@ -207,6 +213,10 @@ class TestStringMethods(unittest.TestCase):
         data = self.session.get(self.ref_entity, num=2)
         self.assertEqual(2, len(data))
 
+    def test_get_batch(self):
+        data = self.session.get(self.ref_entity, batch_size=2)
+        self.assertEqual(self.expected_ref_data, data)
+        
     def test_get_expand(self):
         data = self.session.get(self.ref_entity.replace('Ref', ''), expand='xcomputedxref')
         first_item = data[0]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,5 @@
-import unittest, sys, os
+import os
+import unittest
 
 import molgenis.client as molgenis
 
@@ -27,13 +28,14 @@ class TestStringMethods(unittest.TestCase):
                                       "permission on entity type 'User' with id 'sys_sec_User'.".format(api_url)
     user_entity = 'sys_sec_User'
     ref_entity = 'org_molgenis_test_python_TypeTestRef'
+    entity = 'org_molgenis_test_python_TypeTest'
     expected_ref_data = [
-                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref1', 'value': 'ref1', 'label': 'label1'},
-                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref2', 'value': 'ref2', 'label': 'label2'},
-                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref3', 'value': 'ref3', 'label': 'label3'},
-                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref4', 'value': 'ref4', 'label': 'label4'},
-                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref5', 'value': 'ref5', 'label': 'label5'},
-                    ]
+        {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref1', 'value': 'ref1', 'label': 'label1'},
+        {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref2', 'value': 'ref2', 'label': 'label2'},
+        {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref3', 'value': 'ref3', 'label': 'label3'},
+        {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref4', 'value': 'ref4', 'label': 'label4'},
+        {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref5', 'value': 'ref5', 'label': 'label5'},
+    ]
     session = molgenis.Session(api_url)
     session.login('admin', password)
 
@@ -166,7 +168,7 @@ class TestStringMethods(unittest.TestCase):
             self.session.update_one(self.ref_entity, 'ref55', 'label', 'updated-label55')
         except Exception as e:
             raise Exception(e)
-        item55 = self.session.get_by_id(self.ref_entity, "ref55", ["label"])
+        item55 = self.session.get_by_id(self.ref_entity, "ref55", "label")
         self.assertEqual("updated-label55", item55["label"])
         self.session.delete(self.ref_entity, 'ref55')
 
@@ -216,16 +218,16 @@ class TestStringMethods(unittest.TestCase):
     def test_get_batch(self):
         data = self.session.get(self.ref_entity, batch_size=2)
         self.assertEqual(self.expected_ref_data, data)
-        
+
     def test_get_expand(self):
-        data = self.session.get(self.ref_entity.replace('Ref', ''), expand='xcomputedxref')
+        data = self.session.get(self.entity, expand='xcomputedxref')
         first_item = data[0]
         expected = {"_href": "/api/v2/org_molgenis_test_python_Location/5", "Chromosome": "str1", "Position": 5}
         self.assertEqual(47, len(first_item))
         self.assertEqual(expected, first_item['xcomputedxref'])
 
     def test_get_expand_attrs(self):
-        data = self.session.get(self.ref_entity.replace('Ref', ''), expand='xcomputedxref',
+        data = self.session.get(self.entity, expand='xcomputedxref',
                                 attributes='id,xcomputedxref')
         first_item = data[0]
         expected = {"_href": "/api/v2/org_molgenis_test_python_Location/5", "Chromosome": "str1", "Position": 5}
@@ -244,6 +246,21 @@ class TestStringMethods(unittest.TestCase):
                           'lookupAttribute': True, 'isAggregatable': False,
                           'validationExpression': "$('username').matches(/^[\\S].+[\\S]$/).value()"},
                          meta)
+
+    def test_get_by_id(self):
+        data = self.session.get_by_id(self.ref_entity, 'ref1')
+        del data['_meta']
+        self.assertEqual(self.expected_ref_data[0], data)
+
+    def test_get_by_id_expand(self):
+        data = self.session.get_by_id(self.entity, '1', expand='xcomputedxref')
+        expected = {"_href": "/api/v2/org_molgenis_test_python_Location/5", "Chromosome": "str1", "Position": 5}
+        self.assertEqual(expected, data['xcomputedxref'])
+
+    def test_get_by_id_no_expand(self):
+        data = self.session.get_by_id(self.entity, '1')
+        expected = {"_href": "/api/v2/org_molgenis_test_python_Location/5", "Position": 5}
+        self.assertEqual(expected, data['xcomputedxref'])
 
     def test_build_api_url_complex(self):
         base_url = 'https://test.frl/api/test'


### PR DESCRIPTION
When using `get_by_id` together with `expand`, returned response is exactly the same as without using `expand`. However, it should return a response with expand-attribute expanded, showing all attributes of that entity. 

In current pull-request, this is fixed by using `_build_api_url` to retrieve correctly formatted attributes.

Updated the documentation as well, including an example of how to use multiple attributes in expand.