### PR TITLE
Enable batch retrieval of large number of entities

### DIFF
--- a/molgenis/client.py
+++ b/molgenis/client.py
@@ -249,11 +249,10 @@ class Session:
     def upload_zip(self, meta_data_zip):
         """Uploads a given zip with data and metadata"""
         header = self._get_token_header()
-        zip_file = open(os.path.abspath(meta_data_zip), 'rb')
-        files = {'file': zip_file}
-        url = self._url.strip('/api/') + '/plugin/importwizard/importFile'
-        response = requests.post(url, headers=header, files=files)
-        zip_file.close()
+        with open(os.path.abspath(meta_data_zip), 'rb') as zip_file:
+            files = {'file': zip_file}
+            url = self._url.strip('/api/') + '/plugin/importwizard/importFile'
+            response = requests.post(url, headers=header, files=files)
         try:
             response.raise_for_status()
         except requests.RequestException as ex:

--- a/molgenis/client.py
+++ b/molgenis/client.py
@@ -3,11 +3,12 @@ import os
 import requests
 
 try:
-    from urllib.parse import quote_plus
+    from urllib.parse import quote_plus, urlparse, parse_qs
 except ImportError:
     # Python 2
     # noinspection PyUnresolvedReferences
     from urllib import quote_plus
+    from urlparse import urlparse, parse_qs
 
 
 class MolgenisRequestError(Exception):
@@ -93,9 +94,9 @@ class Session:
         response.close()
         return result
 
-    def get(self, entity, q=None, attributes=None, num=100, start=0, sort_column=None, sort_order=None, raw=False,
+    def get(self, entity, q=None, attributes=None, num=None, batch_size=100, start=0, sort_column=None, sort_order=None, raw=False,
             expand=None):
-        """Retrieves entity rows from an entity repository.
+        """Retrieves all entity rows from an entity repository.
 
         Args:
         entity -- fully qualified name of the entity
@@ -103,7 +104,8 @@ class Session:
             (https://molgenis.gitbooks.io/molgenis/content/developer_documentation/ref-RSQL.html)
         attributes -- The list of attributes to retrieve
         expand -- the attributes to expand
-        num -- the amount of entity rows to retrieve (maximum is 10,000)
+        num -- the maximum amount of entity rows to retrieve
+        batch_size - the amount of entity rows to retrieve per time (max. 10.000)
         start -- the index of the first row to retrieve (zero indexed)
         sortColumn -- the attribute to sort on
         sortOrder -- the order to sort in
@@ -116,9 +118,45 @@ class Session:
         >>> session.get(entity='Person', sort_column='age', sort_order='desc')
         >>> session.get('Person', raw=True)
         """
+        if not sort_column:  # Ensure correct ordering for batched retrieval for old Molgenis instances
+            sort_column = self.get_entity_meta_data(entity)['idAttribute']
+
+        batch_start = start
+        items = []
+        while not num or len(items) < num:  # Keep pulling in batches
+            response = self._get_batch(
+                                    entity=entity,
+                                    q=q,
+                                    attributes=attributes,
+                                    batch_size=batch_size,
+                                    start=batch_start,
+                                    sort_column=sort_column,
+                                    sort_order=sort_order,
+                                    raw=True,
+                                    expand=expand)
+            if raw:
+                return response  # Simply return the first batch response JSON
+            else:
+                items.extend(response['items'])
+
+            if 'nextHref' in response:  # There is more to fetch
+                decomposed_url = urlparse(response['nextHref'])
+                query_part_url = parse_qs(decomposed_url.query)
+                batch_start = query_part_url['start'][0]
+            else:
+                break  # We caught them all
+
+        if num:  # Truncate items
+            items = items[:num]
+
+        return items
+
+    def _get_batch(self, entity, q=None, attributes=None, batch_size=100, start=0, sort_column=None, sort_order=None,
+                   raw=False, expand=None):
+        """ Retrieves a batch of entity rows from an entity repository. """
         possible_options = {'q': q,
                             'attrs': [attributes, expand],
-                            'num': num,
+                            'num': batch_size,
                             'start': start,
                             'sort': [sort_column, sort_order]}
 
@@ -130,10 +168,10 @@ class Session:
         except requests.RequestException as ex:
             self._raise_exception(ex)
 
-        if not raw:
-            return response.json()["items"]
-        else:
+        if raw:
             return response.json()
+        else:
+            return response.json()["items"]
 
     def add(self, entity, data=None, files=None, **kwargs):
         """Adds a single entity row to an entity repository.
@@ -235,7 +273,7 @@ class Session:
             self._raise_exception(ex)
 
         return response.json()
-
+    
     def get_attribute_meta_data(self, entity, attribute):
         """Retrieves the metadata for a single attribute of an entity repository."""
         response = self._session.get(self._url + "v1/" + quote_plus(entity) + "/meta/" + quote_plus(attribute),

--- a/molgenis/client.py
+++ b/molgenis/client.py
@@ -67,6 +67,7 @@ class Session:
 
         self._token = None
         self._session.cookies.clear()
+        self._session.close
 
     def get_by_id(self, entity, id_, attributes=None, expand=None):
         """Retrieves a single entity row from an entity repository.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -70,6 +70,8 @@ class TestStringMethods(unittest.TestCase):
             s.get(self.user_entity)
         except Exception as e:
             message = e.args[0]
+            response = e.args[1]
+            response.connection.close()
             self.assertEqual(self.no_readmeta_permission_user_msg, message)
 
     def test_no_login_and_get_MolgenisUser(self):
@@ -78,6 +80,8 @@ class TestStringMethods(unittest.TestCase):
             s.get(self.user_entity)
         except Exception as e:
             message = e.args[0]
+            response = e.args[1]
+            response.connection.close()
             self.assertEqual(self.no_readmeta_permission_user_msg, message)
 
     def test_upload_zip(self):
@@ -311,4 +315,4 @@ class TestStringMethods(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main(verbosity=2)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -27,6 +27,13 @@ class TestStringMethods(unittest.TestCase):
                                       "permission on entity type 'User' with id 'sys_sec_User'.".format(api_url)
     user_entity = 'sys_sec_User'
     ref_entity = 'org_molgenis_test_python_TypeTestRef'
+    expected_ref_data = [
+                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref1', 'value': 'ref1', 'label': 'label1'},
+                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref2', 'value': 'ref2', 'label': 'label2'},
+                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref3', 'value': 'ref3', 'label': 'label3'},
+                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref4', 'value': 'ref4', 'label': 'label4'},
+                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref5', 'value': 'ref5', 'label': 'label5'},
+                    ]
     session = molgenis.Session(api_url)
     session.login('admin', password)
 
@@ -67,7 +74,7 @@ class TestStringMethods(unittest.TestCase):
         s.get(self.user_entity)
         s.logout()
         try:
-            s.get(self.user_entity)
+            s._get_batch(self.user_entity)
         except Exception as e:
             message = e.args[0]
             response = e.args[1]
@@ -77,7 +84,7 @@ class TestStringMethods(unittest.TestCase):
     def test_no_login_and_get_MolgenisUser(self):
         s = molgenis.Session(self.api_url)
         try:
-            s.get(self.user_entity)
+            s._get_batch(self.user_entity)
         except Exception as e:
             message = e.args[0]
             response = e.args[1]
@@ -190,12 +197,7 @@ class TestStringMethods(unittest.TestCase):
 
     def test_get(self):
         data = self.session.get(self.ref_entity)
-        expected = [{'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref1', 'value': 'ref1', 'label': 'label1'},
-                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref2', 'value': 'ref2', 'label': 'label2'},
-                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref3', 'value': 'ref3', 'label': 'label3'},
-                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref4', 'value': 'ref4', 'label': 'label4'},
-                    {'_href': '/api/v2/org_molgenis_test_python_TypeTestRef/ref5', 'value': 'ref5', 'label': 'label5'}]
-        self.assertEqual(expected, data)
+        self.assertEqual(self.expected_ref_data, data)
 
     def test_get_raw(self):
         data = self.session.get(self.ref_entity, raw=True)
@@ -211,6 +213,10 @@ class TestStringMethods(unittest.TestCase):
         data = self.session.get(self.ref_entity, num=2)
         self.assertEqual(2, len(data))
 
+    def test_get_batch(self):
+        data = self.session.get(self.ref_entity, batch_size=2)
+        self.assertEqual(self.expected_ref_data, data)
+        
     def test_get_expand(self):
         data = self.session.get(self.ref_entity.replace('Ref', ''), expand='xcomputedxref')
         first_item = data[0]
@@ -315,4 +321,4 @@ class TestStringMethods(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main()


### PR DESCRIPTION
When the number of entity row grows beyond 10.000, one needs to 'manually' start batch retrieving via `client.get` calls. This PR implements changes that allow the `client.get`to do this batch retrieval by default if needed.

Some slightly less clean solutions have been kept to keep old behavior of `num` and `raw` and to have this PR not break existing behavior.

In addition, small tweaks for closing socket and file streams during testing have added (since PyCharm kept complaining about those dangling resources).